### PR TITLE
PLATOPS-1271: Explicitly require base64 encoded passwords

### DIFF
--- a/app/uk/gov/hmrc/slacknotifications/controllers/NotificationController.scala
+++ b/app/uk/gov/hmrc/slacknotifications/controllers/NotificationController.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.slacknotifications.controllers
 
 import javax.inject.{Inject, Singleton}
-
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc._
@@ -26,7 +25,7 @@ import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import uk.gov.hmrc.play.bootstrap.http.ErrorResponse
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.slacknotifications.model.NotificationRequest
-import uk.gov.hmrc.slacknotifications.services.{AuthService, NotificationService, Service}
+import uk.gov.hmrc.slacknotifications.services.{AuthService, NotificationService}
 
 import scala.concurrent.Future
 
@@ -47,7 +46,7 @@ class NotificationController @Inject()(authService: AuthService, notificationSer
   }
 
   def withAuthorization(block: => Future[Result])(implicit hc: HeaderCarrier): Future[Result] = {
-    val maybeService = hc.authorization.flatMap(Service.fromAuthorization)
+    val maybeService = hc.authorization.flatMap(AuthService.Service.fromAuthorization)
     if (authService.isAuthorized(maybeService)) {
       block
     } else {

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -12,7 +12,7 @@ object MicroServiceBuild extends Build with MicroService {
     "uk.gov.hmrc"           %% "play-reactivemongo" % "6.2.0",
     "org.typelevel"         %% "cats-core"          % "1.0.1",
     "uk.gov.hmrc"           %% "bootstrap-play-25"  % "1.4.0",
-    "com.github.pureconfig" %% "pureconfig"         % "0.8.0",
+    "com.github.pureconfig" %% "pureconfig"         % "0.9.1",
     ws,
     cache
   )

--- a/test/uk/gov/hmrc/slacknotifications/controllers/NotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/controllers/NotificationControllerSpec.scala
@@ -18,8 +18,6 @@ package uk.gov.hmrc.slacknotifications.controllers
 
 import org.mockito.Matchers.{any, eq => is}
 import org.mockito.Mockito.when
-import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
@@ -27,8 +25,9 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Headers, Result}
 import play.api.test.FakeRequest
 import play.test.Helpers
+import uk.gov.hmrc.slacknotifications.services.AuthService.Service
 import uk.gov.hmrc.slacknotifications.services.NotificationService.NotificationResult
-import uk.gov.hmrc.slacknotifications.services.{AuthService, NotificationService, Service}
+import uk.gov.hmrc.slacknotifications.services.{AuthService, NotificationService}
 
 import scala.concurrent.Future
 


### PR DESCRIPTION
The standard way of specifying config values with `.base64` suffix didn't work here which is why I'm expecting that all values be base64 encoded.