### PR TITLE
BDOG-450 allow configuring a user emoji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ test-result
 tmp
 .idea_modules
 bin
+conf/local.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: scala
+script: sbt test
+jdk:
+  - openjdk8
+cache:
+  directories:
+    - '$HOME/.ivy2/cache'
+services:
+  - mongodb
+addons:
+  apt:
+    sources:
+      - mongodb-3.0-precise
+    packages:
+      - mongodb-org-server

--- a/README.md
+++ b/README.md
@@ -11,16 +11,36 @@ This service uses Basic Auth for access control. If you want to use it please co
 
 ## Adding new users able to send Slack Notifications
 
+The list of users that are able to use the service is predefined by an array in the config:
+
+```
+auth {
+    authorizedServices = [
+        {
+            name = test
+            password = "dGVzdA=="
+            displayName = "My Bot"
+            userEmoji = ":male-mechanic:"
+        }
+    ]
+}
+```
+Where:
+ * `name` is the username
+ * `password` is a base64 encoded password for the user
+ * Optional: `displayName` is a friendly name to use for sending messages as. If not set, will use `name` instead
+ * Optional: `userEmoji` is the icon to use for when sending messages for this user
+
+### In HMRC
+
 If you would like to add a new user that is able to send Slack notifications then you will need to submit a PR to the following repos:
 
   1. https://github.com/hmrc/app-config-platapps-labs/blob/master/slack-notifications.yaml#L73-L74
   1. https://github.com/hmrc/app-config-platapps-live/blob/master/slack-notifications.yaml#L75-L76
 
-Passwords need to be base64 encoded and then encrypted (as described in the configs above)
+> Remember to base64 and then encrypt the passwords (as described in the configs above)
 
 Once we receive the PR we will review, before redeploying the app.
-
-A user's notifications will be sent using the `displayName` in the above config file if configured. Otherwise, the `name` will be used.
 
 **N.B.** This only applies to users within the HMRC organisation on github
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # slack-notifications
 
-[![Build Status](https://travis-ci.org/hmrc/slack-notifications.svg)](https://travis-ci.org/hmrc/slack-notifications) [ ![Download](https://api.bintray.com/packages/hmrc/releases/slack-notifications/images/download.svg) ](https://bintray.com/hmrc/releases/slack-notifications/_latestVersion)
+[![Build Status](https://travis-ci.org/hmrc/slack-notifications.svg)](https://travis-ci.org/hmrc/slack-notifications) [![Download](https://api.bintray.com/packages/hmrc/releases/slack-notifications/images/download.svg) ](https://bintray.com/hmrc/releases/slack-notifications/_latestVersion)
 
 This service enables sending slack notifications on the MDTP.
 

--- a/app/uk/gov/hmrc/slacknotifications/JsonHelpers.scala
+++ b/app/uk/gov/hmrc/slacknotifications/JsonHelpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/connectors/SlackConnector.scala
+++ b/app/uk/gov/hmrc/slacknotifications/connectors/SlackConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/connectors/TeamsAndRepositoriesConnector.scala
+++ b/app/uk/gov/hmrc/slacknotifications/connectors/TeamsAndRepositoriesConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/connectors/UserManagementConnector.scala
+++ b/app/uk/gov/hmrc/slacknotifications/connectors/UserManagementConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/controllers/NotificationController.scala
+++ b/app/uk/gov/hmrc/slacknotifications/controllers/NotificationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/model/ChannelLookup.scala
+++ b/app/uk/gov/hmrc/slacknotifications/model/ChannelLookup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/model/NotificationRequest.scala
+++ b/app/uk/gov/hmrc/slacknotifications/model/NotificationRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/model/NotificationRequest.scala
+++ b/app/uk/gov/hmrc/slacknotifications/model/NotificationRequest.scala
@@ -27,7 +27,8 @@ final case class MessageDetails(
 
 object MessageDetails {
   implicit val reads: Reads[MessageDetails] = (
-    (__ \ "text").read[String] and (__ \ "attachments").readNullable[Seq[Attachment]].map(_.getOrElse(Nil))
+    (__ \ "text").read[String] and
+      (__ \ "attachments").readNullable[Seq[Attachment]].map(_.getOrElse(Nil))
   )(MessageDetails.apply _)
 }
 

--- a/app/uk/gov/hmrc/slacknotifications/model/ServiceConfig.scala
+++ b/app/uk/gov/hmrc/slacknotifications/model/ServiceConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/model/ServiceConfig.scala
+++ b/app/uk/gov/hmrc/slacknotifications/model/ServiceConfig.scala
@@ -16,4 +16,10 @@
 
 package uk.gov.hmrc.slacknotifications.model
 
-case class ServiceConfig(name: String, password: String, displayName: Option[String])
+import pureconfig.{CamelCase, ConfigFieldMapping, ProductHint}
+
+case class ServiceConfig(name: String, password: String, displayName: Option[String], userEmoji: Option[String])
+
+object ServiceConfig {
+  implicit def hint[T]: ProductHint[T] = ProductHint[T](ConfigFieldMapping(CamelCase, CamelCase))
+}

--- a/app/uk/gov/hmrc/slacknotifications/model/SlackMessage.scala
+++ b/app/uk/gov/hmrc/slacknotifications/model/SlackMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/services/AuthService.scala
+++ b/app/uk/gov/hmrc/slacknotifications/services/AuthService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/services/NotificationService.scala
+++ b/app/uk/gov/hmrc/slacknotifications/services/NotificationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/services/UserManagementService.scala
+++ b/app/uk/gov/hmrc/slacknotifications/services/UserManagementService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/slacknotifications/utils/WhitelistedLink.scala
+++ b/app/uk/gov/hmrc/slacknotifications/utils/WhitelistedLink.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2019 HM Revenue & Customs
+# Copyright 2020 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -174,9 +174,10 @@ exclusions {
 auth {
     authorizedServices = [
         {
-            name = leak-detection
-            password = development-only
-            displayName = leak-detection
+            name = test
+            password = "dGVzdA==" # 'test' (passwords are base64 encoded)
+            displayName = "My Bot"
+            userEmoji = ":male-mechanic:"
         }
     ]
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,12 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 

--- a/test/uk/gov/hmrc/slacknotifications/connectors/UserManagementConnectorSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/connectors/UserManagementConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/slacknotifications/connectors/UserManagementConnectorSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/connectors/UserManagementConnectorSpec.scala
@@ -21,7 +21,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import play.api.{Configuration, Environment, Play}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/uk/gov/hmrc/slacknotifications/controllers/NotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/controllers/NotificationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/slacknotifications/model/ChannelLookupSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/model/ChannelLookupSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/slacknotifications/model/ServiceConfigSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/model/ServiceConfigSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.slacknotifications.model
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.Configuration
+import uk.gov.hmrc.slacknotifications.services.AuthService.Service
+
+class ServiceConfigSpec extends WordSpec with Matchers {
+
+  import pureconfig.syntax._
+  import ServiceConfig.hint
+
+  "ServiceConfig" should {
+
+    "default displayName end userEmoji if not set" in {
+      val service = Service("foo", "bar")
+      val configuration =
+        Configuration(
+          "auth.authorizedServices.0.name"     -> service.name,
+          "auth.authorizedServices.0.password" -> service.password
+        )
+
+      val config      = configuration.underlying.getList("auth.authorizedServices").toOrThrow[List[ServiceConfig]]
+
+      config shouldBe List(ServiceConfig(service.name, service.password, None, None))
+    }
+
+    "use the specified displayName end userEmoji if set" in {
+      val service = Service("foo", "bar")
+      val configuration =
+        Configuration(
+          "auth.authorizedServices.0.name"        -> service.name,
+          "auth.authorizedServices.0.password"    -> service.password,
+          "auth.authorizedServices.0.displayName" -> "custom",
+          "auth.authorizedServices.0.userEmoji"   -> ":some-emoji:"
+        )
+
+      val config      = configuration.underlying.getList("auth.authorizedServices").toOrThrow[List[ServiceConfig]]
+
+      config shouldBe List(ServiceConfig(service.name, service.password, Some("custom"), Some(":some-emoji:")))
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/slacknotifications/model/SlackMessageSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/model/SlackMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/slacknotifications/services/AuthServiceSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/services/AuthServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/slacknotifications/services/NotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/services/NotificationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/slacknotifications/services/UserManagementServiceSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/services/UserManagementServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/slacknotifications/services/UserManagementServiceSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/services/UserManagementServiceSpec.scala
@@ -21,7 +21,7 @@ import net.sf.ehcache.CacheManager
 import org.mockito.Mockito.when
 import org.mockito.Matchers.any
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import play.api.cache.{CacheApi, EhCacheApi}
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/slacknotifications/utils/WhitelistedLinkSpec.scala
+++ b/test/uk/gov/hmrc/slacknotifications/utils/WhitelistedLinkSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Enhances the config for an authorised service to allow customising the emoji used (default for slack seems to be 🙈 )