### PR TITLE
PSEC-1966-update-allowed-domains

### DIFF
--- a/app/uk/gov/hmrc/slacknotifications/utils/LinkUtils.scala
+++ b/app/uk/gov/hmrc/slacknotifications/utils/LinkUtils.scala
@@ -27,6 +27,7 @@ object LinkUtils {
     "github.com",
     "pagerduty.com",
     "console.aws.amazon.com",
+    "health.aws.amazon.com",
     "haveibeenpwned.com"
   )
 


### PR DESCRIPTION
Add health.aws.amazon.com in allowed domains list